### PR TITLE
KodiCraft/issue4

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ plugin(bunch({
 
     // Whether or not to create type declarations for libraries. Recommended when using bun[c/h] with TypeScript. Defaults to true.
     create_d_ts: true,
+
+    // Whether or not to use a cache to avoid re-parsing unchanged header files. Defaults to true.
+    use_cache: true,
 }));
 ```
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,13 @@
   "name": "@kodicraft/bunch",
   "module": "src/index.ts",
   "main": "src/index.ts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
+  "keywords": [
+    "bun",
+    "c", "cpp", "c++",
+    "ffi", "llvm"
+  ],
   "devDependencies": {
     "bun-types": "^1.0.2"
   },

--- a/src/clang.ts
+++ b/src/clang.ts
@@ -1,5 +1,8 @@
 import { spawn } from "bun"
-import { rmSync, existsSync } from "fs"
+import { rmSync, existsSync, readdirSync, mkdirSync } from "fs"
+import { SHA256 } from "bun"
+import { basename } from "path"
+import { BunchConfig } from "."
 
 type Empty = Record<PropertyKey, never>
 type Location = Empty | {
@@ -17,6 +20,55 @@ export interface ASTNode {
     loc: Location
     range: {begin: Location, end: Location}
     inner?: ASTNode[]
+}
+
+export class ASTCache {
+    libname: string
+    hash: string
+    ast: ASTNode
+
+    constructor(libname: string, hash: string, ast: ASTNode) {
+        this.libname = libname
+        this.hash = hash
+        this.ast = ast
+    }
+
+    async Check(lib: string): Promise<boolean> {
+        const hash = SHA256.hash(await Bun.file(lib).arrayBuffer()).toString()
+        return hash === this.hash
+    }
+
+    toString(): string {
+        return JSON.stringify(this)
+    }
+
+    static async FromFile(lib: string, ast: ASTNode): Promise<ASTCache> {
+        const hash = SHA256.hash(await Bun.file(lib).arrayBuffer()).toString()
+        return new ASTCache(lib, hash, ast)
+    }
+
+    static async TryCache(lib: string, cachedir: string): Promise<ASTCache | undefined> {
+        if (!existsSync(cachedir)) {
+            mkdirSync(cachedir, {recursive: true})
+        }
+        const dirList = readdirSync(cachedir)
+        const filename = basename(lib)
+        const cacheFiles = dirList.filter((file) => file == filename + ".astcache" )
+        if (cacheFiles.length == 0) { return undefined }
+
+        // Evaluate the file's hash
+        const hash = SHA256.hash(await Bun.file(lib).arrayBuffer()).toString()
+        for (const file of cacheFiles) {
+            const cache = JSON.parse(await Bun.file(cachedir + "/" + file).text()) as ASTCache
+            if (cache.hash == hash) {
+                return cache
+            } else {
+                rmSync(file)
+            }
+        }
+
+        return undefined
+    }
 }
 
 // The nodes that we are interested in are:
@@ -196,7 +248,16 @@ export function GetTypeDefs(ast: ASTNode): Typedefs {
 }
 type Typedefs = {[key: string]: string | undefined}
 
-export async function CreateAST(filePath: string): Promise<ASTNode> {
+export async function CreateAST(filePath: string, config: BunchConfig): Promise<ASTNode> {
+
+    if(config.use_cache) {
+        const cacheDir = config.bunch_dir + "/cache"
+        const cache = await ASTCache.TryCache(filePath, cacheDir)
+        if (cache) {
+            return cache.ast
+        }
+    }
+
     // Run clang on the file and get the AST
     const cmd = ["clang", "-Xclang", "-ast-dump=json", "-fsyntax-only", filePath]
     const proc = spawn({cmd: cmd, stdout: "pipe"})
@@ -212,7 +273,22 @@ export async function CreateAST(filePath: string): Promise<ASTNode> {
         // testFile.write(chunk)
     }
     // testFile.flush()
-    return ParseAST(text)
+    const ast = ParseAST(text)
+
+    if(config.use_cache) {
+        const cacheDir = config.bunch_dir + "/cache"
+
+        if (!existsSync(cacheDir)) {
+            mkdirSync(cacheDir, {recursive: true})
+        }
+
+        const cache = await ASTCache.FromFile(filePath, ast)
+        const cacheFile = Bun.file(cacheDir + "/" + basename(filePath) + ".astcache").writer()
+        cacheFile.write(cache.toString())
+        cacheFile.flush()
+    }
+
+    return ast
 }
 
 // Built-in types that we can match via string comparison

--- a/src/clang.ts
+++ b/src/clang.ts
@@ -63,7 +63,7 @@ export class ASTCache {
             if (cache.hash == hash) {
                 return cache
             } else {
-                rmSync(file)
+                rmSync(cachedir + "/" + file)
             }
         }
 
@@ -280,6 +280,10 @@ export async function CreateAST(filePath: string, config: BunchConfig): Promise<
 
         if (!existsSync(cacheDir)) {
             mkdirSync(cacheDir, {recursive: true})
+        }
+
+        if (existsSync(cacheDir + "/" + basename(filePath) + ".astcache")) {
+            rmSync(cacheDir + "/" + basename(filePath) + ".astcache")
         }
 
         const cache = await ASTCache.FromFile(filePath, ast)

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export type BunchConfig = {
     lib_ext?: string
     bunch_dir: string
     create_d_ts: boolean
+    use_cache: boolean
 }
 
 // This is all strings because it will be used to generate typescript code.
@@ -28,6 +29,7 @@ export function prepare_config(config: Partial<BunchConfig>): BunchConfig {
         honor_ld_preload: config.honor_ld_preload ?? true,
         bunch_dir: config.bunch_dir ?? "./.bunch",
         create_d_ts: config.create_d_ts ?? true,
+        use_cache: config.use_cache ?? true,
     }
 }
 
@@ -65,7 +67,7 @@ export default function bunch(config: Partial<BunchConfig>): BunPlugin {
                     throw new Error(`Library ${libName} not found!`)
                 }
 
-                const ast = await CreateAST(args.path)
+                const ast = await CreateAST(args.path, prepare_config(config))
                 const typedefs = GetTypeDefs(ast)
                 const symbols = GetAllSymbols(ast, typedefs)
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -3,6 +3,25 @@ import { FunctionDecl, ParamVarDecl } from '../src/clang'
 import { FFIType } from 'bun:ffi'
 import { prepare_config } from '../src/index'
 
+test("Cache", async () => {
+    const fs = await import('fs')
+    const { ASTCache } = await import('../src/clang')
+
+    // Clear the cache
+    if (fs.existsSync('./.bunch/cache')) {
+        fs.rmSync('./.bunch/cache', {recursive: true})
+    }
+
+    // Trying to load from cache now should return undefined
+    expect(await ASTCache.TryCache('./test/simple.h', './.bunch/cache')).toBeUndefined()
+
+    // Now import the file normally
+    var simple = await import('simple.h')
+
+    // Now the cache should have the file
+    expect(await ASTCache.TryCache('./test/simple.h', './.bunch/cache')).toBeDefined()
+})
+
 test("Load simple", async () => {
     var simple = await import('simple.h')
     expect(simple).toBeDefined()

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'bun:test'
 import { FunctionDecl, ParamVarDecl } from '../src/clang'
 import { FFIType } from 'bun:ffi'
+import { prepare_config } from '../src/index'
 
 test("Load simple", async () => {
     var simple = await import('simple.h')
@@ -61,7 +62,7 @@ test("Bad library", async () => {
 test("Parse AST", async () => {
     const { CreateAST, find_nodes, isFunctionDecl, isParamVarDecl, isTypedefDecl } = await import('../src/clang')
   
-    var ast = await CreateAST('./test/asttest.h')
+    var ast = await CreateAST('./test/asttest.h', prepare_config({}))
     expect(ast).toBeDefined()
     expect(ast.kind).toEqual("TranslationUnitDecl")
 
@@ -78,7 +79,7 @@ test("Parse AST", async () => {
 test("Convert C types to TS types", async () => {
     const { CreateAST, find_nodes, GetTypeDefs, ctype_to_type } = await import('../src/clang')
 
-    var ast = await CreateAST('./test/typetest.h')
+    var ast = await CreateAST('./test/typetest.h', prepare_config({}))
     expect(ast).toBeDefined()
     
     var typedefs = GetTypeDefs(ast)
@@ -102,7 +103,7 @@ test("Convert C types to TS types", async () => {
 test("Create Symbols from AST", async () => {
     const { CreateAST, GetTypeDefs, GetAllSymbols, GetSymbolFromNode } = await import('../src/clang')
 
-    var ast = await CreateAST('./test/symboltest.h')
+    var ast = await CreateAST('./test/symboltest.h', prepare_config({}))
     expect(ast).toBeDefined()
     const typedefs = GetTypeDefs(ast)
     expect(typedefs).toBeDefined()


### PR DESCRIPTION
This PR implements caching the AST. This reduces useless calls to clang which can improve performance and reliability.

# User-facing changes
- New `use_cache` config option allowing the user to enable or disable caching
- New directory `cache` is created and used for storing the AST

# Internal changes
- `clang.CreateAST` now requires a reference to the config object
- `Cache` test added for checking cache usages